### PR TITLE
Add skeleton screens

### DIFF
--- a/neizlesek/app/(tabs)/_layout.tsx
+++ b/neizlesek/app/(tabs)/_layout.tsx
@@ -30,14 +30,45 @@ export default function TabLayout() {
         name="index"
         options={{
           title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="house.fill" color={color} />
+          ),
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="watchlist"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: 'Watchlist',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="bookmark.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="watched"
+        options={{
+          title: 'Watched',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="checkmark.circle.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="favorites"
+        options={{
+          title: 'Favorites',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="heart.fill" color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="person.fill" color={color} />
+          ),
         }}
       />
     </Tabs>

--- a/neizlesek/app/details.tsx
+++ b/neizlesek/app/details.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Details() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Details</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/app/favorites.tsx
+++ b/neizlesek/app/favorites.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Favorites() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Favorites</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/app/profile.tsx
+++ b/neizlesek/app/profile.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Profile() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Profile</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/app/recommendations.tsx
+++ b/neizlesek/app/recommendations.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Recommendations() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Recommendations</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/app/watched.tsx
+++ b/neizlesek/app/watched.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Watched() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Watched</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/app/watchlist.tsx
+++ b/neizlesek/app/watchlist.tsx
@@ -1,0 +1,10 @@
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+
+export default function Watchlist() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Watchlist</ThemedText>
+    </ThemedView>
+  );
+}

--- a/neizlesek/components/ui/IconSymbol.tsx
+++ b/neizlesek/components/ui/IconSymbol.tsx
@@ -18,6 +18,10 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'bookmark.fill': 'bookmark',
+  'checkmark.circle.fill': 'check-circle',
+  'heart.fill': 'favorite',
+  'person.fill': 'person',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
## Summary
- scaffold profile, watchlist, watched, favorites, recommendations and details
- wire pages into the tab layout
- extend icon mapping for new tabs

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd23fcab48321addb14a71cfc6bf2